### PR TITLE
LF-44: get balances from chain instead of debank

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,8 @@ import Swap from './components/Swap'
 import Web3ConnectionManager from './components/web3/Web3ConnectionManager'
 import WrappedWeb3ReactProvider from './components/web3/WrappedWeb3ReactProvider'
 import analytics from './services/analytics'
-import { getBalancesForWallet as getBalancesForWalletMainnet } from './services/balanceService'
 import setMetatags from './services/metatags'
 import { initStomt } from './services/stomt'
-import { getDefaultTokenBalancesForWallet as getBalancesForWalletTestnet } from './services/testToken'
 import { getChainById } from './types'
 import NotificationOverlay from './components/NotificationsOverlay'
 
@@ -131,7 +129,6 @@ function App() {
                   return <div className="lifiWrap">
                     <Swap
                       transferChains={transferChains}
-                      getBalancesForWallet={getBalancesForWalletMainnet}
                     />
                   </div>
                 }} />
@@ -144,7 +141,6 @@ function App() {
                   return <div className="lifiWrap">
                     <Swap
                       transferChains={transferChains}
-                      getBalancesForWallet={getBalancesForWalletTestnet}
                     />
                   </div>
                 }} />

--- a/src/components/Swap.tsx
+++ b/src/components/Swap.tsx
@@ -1,38 +1,34 @@
 // LIBS
-import { LoginOutlined, SwapOutlined, SyncOutlined } from '@ant-design/icons';
-import { Web3Provider } from '@ethersproject/providers';
-import { useWeb3React } from '@web3-react/core';
-import { Button, Col, Collapse, Form, InputNumber, Modal, Row, Typography } from 'antd';
-import { Content } from 'antd/lib/layout/layout';
-import Title from 'antd/lib/typography/Title';
-import axios, { CancelTokenSource } from 'axios';
-import BigNumber from 'bignumber.js';
-import { animate, stagger } from "motion";
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { loadTokenListAsTokens } from '../services/tokenListService';
-import { deepClone, formatTokenAmountOnly } from '../services/utils';
-import { Chain, ChainKey, ChainPortfolio, defaultTokens, DepositAction, getChainByKey, Token, TransferStep, WithdrawAction } from '../types';
-import LoadingIndicator from './LoadingIndicator';
-import Route from './Route';
-import './Swap.css';
-import SwapForm from './SwapForm';
-import Swapping from './Swapping';
-import { injected } from './web3/connectors';
-import { readActiveRoutes, readHistoricalRoutes, deleteRoute } from '../services/localStorage';
-import TrasactionsTable from './TransactionsTable';
+import { LoginOutlined, SwapOutlined, SyncOutlined } from '@ant-design/icons'
+import { Web3Provider } from '@ethersproject/providers'
+import { useWeb3React } from '@web3-react/core'
+import { Button, Col, Collapse, Form, InputNumber, Modal, Row, Typography } from 'antd'
+import { Content } from 'antd/lib/layout/layout'
+import Title from 'antd/lib/typography/Title'
+import axios, { CancelTokenSource } from 'axios'
+import BigNumber from 'bignumber.js'
+import { animate, stagger } from "motion"
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { loadTokenListAsTokens } from '../services/tokenListService'
+import { deepClone, formatTokenAmountOnly } from '../services/utils'
+import { Chain, ChainKey, ChainPortfolio, defaultTokens, DepositAction, getChainByKey, Token, TransferStep, WithdrawAction } from '../types'
+import LoadingIndicator from './LoadingIndicator'
+import Route from './Route'
+import './Swap.css'
+import SwapForm from './SwapForm'
+import Swapping from './Swapping'
+import { injected } from './web3/connectors'
+import { readActiveRoutes, readHistoricalRoutes, deleteRoute } from '../services/localStorage'
+import TrasactionsTable from './TransactionsTable'
+import { getBalancesForWalletFromChain } from '../services/balanceService'
 
-const { Panel } = Collapse;
+const { Panel } = Collapse
 
 interface TokenWithAmounts extends Token {
   amount?: BigNumber
   amountRendered?: string
 }
 let source: CancelTokenSource | undefined = undefined
-
-interface SwapProps {
-  transferChains: Chain[]
-  getBalancesForWallet: Function
-}
 
 
 const fadeInAnimation = (element: React.MutableRefObject<HTMLDivElement | null>) => {
@@ -46,9 +42,23 @@ const fadeInAnimation = (element: React.MutableRefObject<HTMLDivElement | null>)
   })
 }
 
+const filterDefaultTokenByChains = (tokens: { [ChainKey: string]: Array<TokenWithAmounts> }, transferChains: Chain[]) => {
+  const result: { [ChainKey: string]: Array<TokenWithAmounts> } = {}
+
+  transferChains.forEach((chain) => {
+    if (tokens[chain.key]) {
+      result[chain.key] = tokens[chain.key]
+    }
+  })
+  return result
+}
+
+interface SwapProps {
+  transferChains: Chain[]
+}
+
 const Swap = ({
   transferChains,
-  getBalancesForWallet,
 }: SwapProps) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [unused, setStateUpdate] = useState<number>(0)
@@ -60,7 +70,7 @@ const Swap = ({
   const [withdrawChain, setWithdrawChain] = useState<ChainKey>(transferChains[1].key)
   const [withdrawAmount, setWithdrawAmount] = useState<BigNumber>(new BigNumber(Infinity))
   const [withdrawToken, setWithdrawToken] = useState<string | undefined>() // tokenId
-  const [tokens, setTokens] = useState<{ [ChainKey: string]: Array<TokenWithAmounts> }>(defaultTokens)
+  const [tokens, setTokens] = useState<{ [ChainKey: string]: Array<TokenWithAmounts> }>(filterDefaultTokenByChains(defaultTokens, transferChains))
   const [refreshTokens, setRefreshTokens] = useState<boolean>(true)
   const [balances, setBalances] = useState<{ [ChainKey: string]: Array<ChainPortfolio> }>()
   const [refreshBalances, setRefreshBalances] = useState<boolean>(true)
@@ -109,13 +119,19 @@ const Swap = ({
     }
   }, [refreshTokens, transferChains])
 
+  const updateBalances = useCallback(() => {
+    if (web3.account) {
+      getBalancesForWalletFromChain(web3.account, tokens)
+        .then(setBalances)
+    }
+  }, [web3.account, tokens])
+
   useEffect(() => {
     if (refreshBalances && web3.account) {
       setRefreshBalances(false)
-      getBalancesForWallet(web3.account, transferChains.map(chain => chain.id))
-        .then(setBalances)
+      updateBalances()
     }
-  }, [refreshBalances, getBalancesForWallet, transferChains, web3.account])
+  }, [refreshBalances, web3.account, updateBalances])
 
   useEffect(() => {
     if (!web3.account) {
@@ -442,32 +458,29 @@ const Swap = ({
         <Modal
           className="swapModal"
           visible={selectedRoute.length > 0}
-          onOk={() =>{
+          onOk={() => {
             setselectedRoute([])
-            getBalancesForWallet(web3.account, transferChains.map(chain => chain.id))
-            .then(setBalances)
+            updateBalances()
           }}
           onCancel={() => {
             setselectedRoute([])
-            getBalancesForWallet(web3.account, transferChains.map(chain => chain.id))
-            .then(setBalances)
+            updateBalances()
           }}
-          destroyOnClose = {true}
+          destroyOnClose={true}
           width={700}
           footer={null}
         >
           <Swapping
-          route={selectedRoute}
-          updateRoute={(route: any) => {
-            setActiveRoutes(readActiveRoutes())
-            setHistoricalRoutes(readHistoricalRoutes())
-          }}
-          onSwapDone = {(route: TransferStep[]) => {
-            setActiveRoutes(readActiveRoutes())
-            setHistoricalRoutes(readHistoricalRoutes())
-            getBalancesForWallet(web3.account, transferChains.map(chain => chain.id))
-            .then(setBalances)
-          }}
+            route={selectedRoute}
+            updateRoute={(route: any) => {
+              setActiveRoutes(readActiveRoutes())
+              setHistoricalRoutes(readHistoricalRoutes())
+            }}
+            onSwapDone={(route: TransferStep[]) => {
+              setActiveRoutes(readActiveRoutes())
+              setHistoricalRoutes(readHistoricalRoutes())
+              updateBalances()
+            }}
           ></Swapping>
         </Modal>
       }

--- a/src/components/web3/connectors.ts
+++ b/src/components/web3/connectors.ts
@@ -1,7 +1,7 @@
-import { InjectedConnector } from '@web3-react/injected-connector';
-import { NetworkConnector } from '@web3-react/network-connector';
-import { providers } from 'ethers';
-import { ChainId, getChainById } from '../../types';
+import { InjectedConnector } from '@web3-react/injected-connector'
+import { NetworkConnector } from '@web3-react/network-connector'
+import { providers } from 'ethers'
+import { ChainId, getChainById } from '../../types'
 
 const CHAINS = {
   // Mainnet
@@ -11,6 +11,7 @@ const CHAINS = {
   XDAI: 100,
   FANTOM: 250,
   ARBITRUM: 42161,
+  OPTIMISTIC: 10,
 
   // Testnet
   ROPSTEN: 3,
@@ -29,7 +30,7 @@ const CHAINS = {
   KOV: ChainId.KOV,
   ONE: ChainId.ONE,
   ONET: ChainId.ONET,
-};
+}
 
 const RPC_URLS: { [chainId: number]: string } = {
   // Mainnet
@@ -39,6 +40,7 @@ const RPC_URLS: { [chainId: number]: string } = {
   [CHAINS.XDAI]: process.env.REACT_APP_RPC_URL_XDAI || getChainById(CHAINS.XDAI).metamask.rpcUrls[0],
   [CHAINS.FANTOM]: process.env.REACT_APP_RPC_URL_FANTOM || getChainById(CHAINS.FANTOM).metamask.rpcUrls[0],
   [CHAINS.ARBITRUM]: process.env.REACT_APP_RPC_URL_ARBITRUM || getChainById(CHAINS.ARBITRUM).metamask.rpcUrls[0],
+  [CHAINS.OPTIMISTIC]: process.env.REACT_APP_RPC_URL_OPTIMISTIC || getChainById(CHAINS.OPTIMISTIC).metamask.rpcUrls[0],
 
   // Testnet
   [CHAINS.ROPSTEN]: process.env.REACT_APP_RPC_URL_ROPSTEN || getChainById(CHAINS.ROPSTEN).metamask.rpcUrls[0],
@@ -56,10 +58,12 @@ const RPC_URLS: { [chainId: number]: string } = {
   [CHAINS.FSN]: 'https://fsnmainnet2.anyswap.exchange',
   [CHAINS.KOV]: 'https://kovan.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
   [CHAINS.ONE]: 'https://api.harmony.one',
-  [CHAINS.ONET]:  'https://api.s0.b.hmny.io',
-};
+  [CHAINS.ONET]: 'https://api.s0.b.hmny.io',
+}
 
-
+// based on:
+// - https://github.com/sushiswap/sushiswap-sdk/blob/canary/src/constants/addresses.ts#L323
+// - https://github.com/joshstevens19/ethereum-multicall#multicall-contracts
 const MULTICALL_ADDRESSES: { [chainId: number]: string } = {
   // Mainnet
   [CHAINS.MAINNET]: '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696',
@@ -73,6 +77,7 @@ const MULTICALL_ADDRESSES: { [chainId: number]: string } = {
   [CHAINS.FSN]: '0x0769fd68dFb93167989C6f7254cd0D766Fb2841F',
   [CHAINS.KOV]: '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696',
   [CHAINS.ONE]: '0xdDCbf776dF3dE60163066A5ddDF2277cB445E0F3',
+  // [CHAINS.OPTIMISTIC]: '',
 
   // Testnet
   [CHAINS.ROPSTEN]: '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696',
@@ -80,17 +85,17 @@ const MULTICALL_ADDRESSES: { [chainId: number]: string } = {
   [CHAINS.GOERLI]: '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696',
   [CHAINS.KOVAN]: '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696',
   [CHAINS.ARBITRUM_RINKEBY]: '0xa501c031958F579dB7676fF1CE78AD305794d579',
-  [CHAINS.OPTIMISM_KOVAN]: '',
+  // [CHAINS.OPTIMISM_KOVAN]: '',
   [CHAINS.POLYGON_TESTNET]: '0xc1400d49baa8e307B4462cD46E0a20109D25F50f',
   [CHAINS.BSC_TESTNET]: '0xae11C5B5f29A6a25e955F0CB8ddCc416f522AF5C',
-  [CHAINS.ONET]:  '0xdDCbf776dF3dE60163066A5ddDF2277cB445E0F3',
-};
+  // [CHAINS.ONET]:  '',
+}
 
 // cached providers
-const chainProviders: Record<number, providers.FallbackProvider> = {};
+const chainProviders: Record<number, providers.FallbackProvider> = {}
 
 export const getRpcUrls = (chainIds: Array<number>) => {
-  const rpcs : Record<number, string> = {}
+  const rpcs: Record<number, string> = {}
   chainIds.forEach((chainId) => {
     rpcs[chainId] = RPC_URLS[chainId]
   })
@@ -98,7 +103,7 @@ export const getRpcUrls = (chainIds: Array<number>) => {
 }
 
 export const getMulticallAddresses = (chainIds: Array<number>) => {
-  const addresses : Record<number, string> = {}
+  const addresses: Record<number, string> = {}
   chainIds.forEach((chainId) => {
     addresses[chainId] = MULTICALL_ADDRESSES[chainId]
   })
@@ -113,7 +118,7 @@ export const getRpcProvider = (chainId: number) => {
 }
 
 export const getRpcProviders = (chainIds: Array<number>) => {
-  const selectedProviders: Record<number, providers.FallbackProvider> = {};
+  const selectedProviders: Record<number, providers.FallbackProvider> = {}
 
   chainIds.forEach((chainId) => {
     selectedProviders[chainId] = getRpcProvider(chainId)
@@ -123,11 +128,11 @@ export const getRpcProviders = (chainIds: Array<number>) => {
 
 export const injected = new InjectedConnector({
   supportedChainIds: Object.values<number>(CHAINS),
-});
+})
 
 export const network = new NetworkConnector({
   urls: Object.fromEntries(
     Object.values<number>(CHAINS).map(i => [i, RPC_URLS[i]])
   ),
   defaultChainId: CHAINS.MAINNET,
-});
+})

--- a/src/services/balanceService.ts
+++ b/src/services/balanceService.ts
@@ -327,7 +327,7 @@ export const getBalancesFromProviderUsingMulticall = async (
           call: ['getEthBalance(address)(uint256)', address],
           returns: [[
             [token.id, token.name, token.key].join('-'),
-            (val: number) => new BigNumber(val).shiftedBy(-token.decimals).toFixed()
+            (val: BN) => new BigNumber(val.toString()).shiftedBy(-token.decimals).toFixed(),
           ]]
         })
       }
@@ -337,7 +337,7 @@ export const getBalancesFromProviderUsingMulticall = async (
           call: ['balanceOf(address)(uint256)', address],
           returns: [[
             [token.id, token.name, token.key].join('-'),
-            (val: number) => new BigNumber(val).shiftedBy(-token.decimals).toFixed(),
+            (val: BN) => new BigNumber(val.toString()).shiftedBy(-token.decimals).toFixed(),
           ]]
         })
       }

--- a/src/services/balanceService.ts
+++ b/src/services/balanceService.ts
@@ -1,11 +1,12 @@
-import axios from 'axios'
-import { BigNumber } from 'bignumber.js'
-import { constants, ethers } from 'ethers'
-import { getMulticallAddresses, getRpcUrls } from '../components/web3/connectors'
-import { ChainId, ChainKey, chainKeysToObject, ChainPortfolio, defaultTokens, getChainById, Token } from '../types'
-import { deepClone } from './utils'
+import { FallbackProvider } from '@ethersproject/providers'
 // @ts-ignore
 import { createWatcher } from '@makerdao/multicall'
+import axios from 'axios'
+import { BigNumber } from 'bignumber.js'
+import { BigNumber as BN, constants, Contract, ethers } from 'ethers'
+import { getMulticallAddresses, getRpcProvider, getRpcUrls } from '../components/web3/connectors'
+import { ChainId, ChainKey, chainKeysToObject, ChainPortfolio, defaultTokens, getChainById, Token } from '../types'
+import { deepClone } from './utils'
 
 type tokenListDebankT = {
   id: string,
@@ -255,85 +256,142 @@ const getBalancesForWallet = async (walletAdress: string, onChains?: Array<numbe
   return filterPortfolioWithBlacklist(protfolio, tokenBlacklist)
 }
 
-export const getBalanceFromProvider = async (
+export const getBalance = async (
+  address: string,
+  assetId: string,
+  provider: FallbackProvider,
+): Promise<BigNumber> => {
+  let balance
+  if (assetId === constants.AddressZero) {
+    balance = await provider.getBalance(address)
+  } else {
+    const contract = new Contract(assetId, ['function balanceOf(address owner) view returns (uint256)'], provider)
+    balance = await contract.balanceOf(address)
+  }
+  return balance
+}
+
+export const getBalancesFromProvider = async (
   address: string,
   tokens: Array<Token>,
-): Promise<Array<any>> => new Promise((resolve) => {
+): Promise<Array<ChainPortfolio>> => {
+  const chainId = tokens[0].chainId
+  const rpc = getRpcProvider(chainId)
+
+  const promises: Array<Promise<any>> = []
+  const chainPortfolio: Array<ChainPortfolio> = []
+
+  tokens.forEach(async (token) => {
+    const amount = getBalance(address, token.id, rpc).catch((e) => { console.warn(e); return BN.from(0) })
+    promises.push(amount)
+    chainPortfolio.push({
+      id: token.id,
+      name: token.name,
+      symbol: token.key,
+      img_url: '',
+      amount: new BigNumber((await amount).toString()).shiftedBy(-token.decimals),
+      pricePerCoin: new BigNumber(0),
+      verified: false,
+    })
+  })
+
+  await Promise.all(promises)
+
+  return chainPortfolio
+}
+
+export const getBalancesFromProviderUsingMulticall = async (
+  address: string,
+  tokens: Array<Token>,
+): Promise<Array<ChainPortfolio>> => {
+
   // Configuration
   const chainId = tokens[0].chainId
   const config = {
     rpcUrl: getRpcUrls([chainId])[chainId],
     multicallAddress: getMulticallAddresses([chainId])[chainId],
-    interval: 10000
+    interval: 1000000000, // calling stop on the watcher does not actually close the websocket
   }
 
-  // Collect calls we want to make
-  const calls: Array<any> = []
-  tokens.forEach(async (token) => {
-    if (token.id === constants.AddressZero) {
-      calls.push({
-        call: ['getEthBalance(address)(uint256)', address],
-        returns: [[
-          [token.id, token.name, token.key].join('-'),
-          (val: number) => new BigNumber(val).shiftedBy(-token.decimals).toFixed()
-        ]]
-      })
-    }
-    else {
-      calls.push({
-        target: token.id,
-        call: ['balanceOf(address)(uint256)', address],
-        returns: [[
-          [token.id, token.name, token.key].join('-'),
-          (val: number) => new BigNumber(val).shiftedBy(-token.decimals).toFixed(),
-        ]]
-      })
-    }
+  if (!config.multicallAddress) {
+    // Fallback if multicall is not available
+    return getBalancesFromProvider(address, tokens)
+  }
+
+  const promiseWrapper = new Promise((resolve) => {
+    // Collect calls we want to make
+    const calls: Array<any> = []
+    tokens.forEach(async (token) => {
+      if (token.id === constants.AddressZero) {
+        calls.push({
+          call: ['getEthBalance(address)(uint256)', address],
+          returns: [[
+            [token.id, token.name, token.key].join('-'),
+            (val: number) => new BigNumber(val).shiftedBy(-token.decimals).toFixed()
+          ]]
+        })
+      }
+      else {
+        calls.push({
+          target: token.id,
+          call: ['balanceOf(address)(uint256)', address],
+          returns: [[
+            [token.id, token.name, token.key].join('-'),
+            (val: number) => new BigNumber(val).shiftedBy(-token.decimals).toFixed(),
+          ]]
+        })
+      }
+    })
+
+    const watcher = createWatcher(
+      calls,
+      config
+    )
+
+    // Success case
+    watcher.batch().subscribe((updates: any) => {
+      watcher.stop()
+      resolve(updates as any)
+    })
+
+    // Error case
+    watcher.onError((error: any) => {
+      watcher.stop()
+      console.log('failed for', chainId, config)
+      console.warn('Watcher Error:', error)
+      resolve([])
+    })
+
+    // Submit calls
+    watcher.start()
   })
 
-  const watcher = createWatcher(
-    calls,
-    config
-  )
-
-  // Success case
-  watcher.batch().subscribe((updates: any) => {
-    watcher.stop()
-    resolve(updates as any)
+  // parse results
+  const chainPortfolio: Array<ChainPortfolio> = []
+  const amounts = await promiseWrapper as Array<any>
+  amounts.forEach((amount) => {
+    const [token_id, token_name, token_key] = amount['type'].split('-')
+    chainPortfolio.push({
+      id: token_id,
+      name: token_name,
+      symbol: token_key,
+      img_url: '',
+      amount: new BigNumber(amount.value),
+      pricePerCoin: new BigNumber(0),
+      verified: false,
+    })
   })
 
-  // Error case
-  watcher.onError((error: any) => {
-    watcher.stop()
-    console.warn('Watcher Error:', error)
-    resolve([])
-  })
-
-  // Submit calls
-  watcher.start()
-})
+  return chainPortfolio
+}
 
 export const getBalancesForWalletFromChain = async (address: string, tokens: { [ChainKey: string]: Array<Token> }) => {
   const portfolio: { [ChainKey: string]: Array<ChainPortfolio> } = chainKeysToObject([])
   const promises: Array<Promise<any>> = []
   Object.entries(tokens).forEach(async ([chainKey, tokens]) => {
-    const promise = getBalanceFromProvider(address, tokens)
+    const promise = getBalancesFromProviderUsingMulticall(address, tokens)
     promises.push(promise)
-    const amounts = await promise
-
-    amounts.forEach((amount) => {
-      const [token_id, token_name, token_key] = amount['type'].split('-')
-
-      portfolio[chainKey].push({
-        id: token_id,
-        name: token_name,
-        symbol: token_key,
-        img_url: '',
-        amount: new BigNumber(amount.value),
-        pricePerCoin: new BigNumber(0),
-        verified: false,
-      })
-    })
+    portfolio[chainKey] = await promise
   })
 
   await Promise.allSettled(promises)


### PR DESCRIPTION
The DeBank API token balances with too many decimals, which cases errors if users try to use all the tokens we think they have. We have now integrated multicall, which allows us to query balances directly from chain. I added this as the default way to get balances for both main- and testnets. If multicall is not available on a chain we instead fall back to query the balances of every token in a single call. The DeBank API is still used for the dashboard since we aim to show all the token a user have, in the swap we are only interested in token the user can actually swap or transfer (based on the dexs token lists).