### PR TITLE
LF-70: do not try to add native gas token to wallet

### DIFF
--- a/src/components/Swapping.tsx
+++ b/src/components/Swapping.tsx
@@ -29,6 +29,7 @@ import {OneInchExecutionManager} from '../services/1inch.execute';
 import {HopExecutionManager} from '../services/hop.execute';
 import {HorizonExecutionManager} from '../services/horizon.execute';
 import { renderProcessMessage } from '../services/processRenderer';
+import { constants } from 'ethers'
 
 
 interface SwappingProps {
@@ -478,18 +479,27 @@ const Swapping = ({ route, updateRoute, onSwapDone }: SwappingProps) => {
       const {toChain} = getRecevingInfo(lastStep)
       return (<Space direction="vertical">
       <Typography.Text strong>Swap Successful!</Typography.Text>
-      {finalBalance && finalBalance.portfolio &&
-        <Tooltip title="Click to add this token to your wallet.">
-          <span style={{cursor: 'copy'}} onClick={() => switchChainAndAddToken(toChain.id, finalBalance.token)}>
+        {finalBalance && finalBalance.portfolio && (
+          finalBalance.token.id === constants.AddressZero ? (
             <Typography.Text>
               {'You now have '}
               {finalBalance.portfolio.amount.toString().substring(0, 8)}
               {` ${finalBalance.portfolio.symbol}`}
               {` on ${toChain.name}`}
             </Typography.Text>
-          </span>
-        </Tooltip>
-      }
+          ) : (
+            <Tooltip title="Click to add this token to your wallet.">
+              <span style={{ cursor: 'copy' }} onClick={() => switchChainAndAddToken(toChain.id, finalBalance.token)}>
+                <Typography.Text>
+                  {'You now have '}
+                  {finalBalance.portfolio.amount.toString().substring(0, 8)}
+                  {` ${finalBalance.portfolio.symbol}`}
+                  {` on ${toChain.name}`}
+                </Typography.Text>
+              </span>
+            </Tooltip >
+          )
+        )}
       <Link to="/dashboard"><Button type="link">Dashboard</Button></Link>
       </Space>)
     }


### PR DESCRIPTION
After the users did a transfer or swap we show him his new token balance. When hovering the token name the user can add this token to his metamask wallet, because the wallet does not automatically show all tokens a user has. The native gas token on the other hand is always shown at the very top in the wallet, trying to add it to the wallet is not needed and doesn't work. So we should not show this option.