### PR TITLE
Call getActiveTransactions to sync chains before requesting quota

### DIFF
--- a/src/services/nxtp.execute.ts
+++ b/src/services/nxtp.execute.ts
@@ -96,6 +96,7 @@ export class NXTPExecutionManager {
       if(quoteProcess.quote){
         quote = quoteProcess.quote
       } else {
+        await nxtpSDK.getActiveTransactions()
         quote = await nxtp.getTransferQuote(nxtpSDK, fromChainId, srcTokenAddress, toChainId, destTokenAddress, fromAmount.toString(), userAddress)
         if (!quote) {
             throw new Error("No quote found! Please restart the swap.")


### PR DESCRIPTION
nxtp sdk does not sync subgraphs before requesting the transfer quota. Until this is solved we manually sync them again by fetching the active transactions