### PR TITLE
Add Connextscan Links

### DIFF
--- a/src/components/nxtp/SwapXpollinate.tsx
+++ b/src/components/nxtp/SwapXpollinate.tsx
@@ -1000,7 +1000,7 @@ const SwapXpollinate = ({
               Active Transactions ({!sdk ? '-' : (updatingActiveTransactions ? <SyncOutlined spin style={{ verticalAlign: -4 }} /> : activeTransactions.length)})
             </h2>
           )} key="active">
-            <div style={{ overflowX: 'scroll', background: 'white', margin: '10px 20px' }}>
+            <div style={{ overflowX: 'scroll', background: 'white' }}>
               <TransactionsTableNxtp
                 activeTransactions={activeTransactions}
                 executionRoutes={executionRoutes}
@@ -1011,38 +1011,6 @@ const SwapXpollinate = ({
                 tokens={tokens}
               />
             </div>
-          </Collapse.Panel>
-
-          {/* Historical Transactions */}
-          <Collapse.Panel className={web3.account ? '' : 'empty'} header={(
-            <a
-              href={web3.account ? 'https://connextscan.io/address/' + web3.account : 'https://connextscan.io/transactions'}
-              target="_blank"
-              rel="nofollow noreferrer"
-            >
-              <h2
-                style={{ display: 'inline' }}
-              >
-                Historical Transactions (<LinkOutlined />)
-              </h2>
-            </a>
-          )} key="historic">
-          </Collapse.Panel>
-
-          {/* Liquidity */}
-          <Collapse.Panel header={(
-            <a
-              href={'https://connextscan.io/routers'}
-              target="_blank"
-              rel="nofollow noreferrer"
-            >
-              <h2
-                style={{ display: 'inline' }}
-              >
-                Available Liquidity (<LinkOutlined />)
-              </h2>
-            </a>
-          )} key="liquidity">
           </Collapse.Panel>
         </Collapse>
 
@@ -1133,6 +1101,36 @@ const SwapXpollinate = ({
 
             </div>
           </Col>
+        </Row>
+
+        {/* Historical Transactions */}
+        <Row style={{ marginTop: 40 }} justify={"center"}>
+          <a
+            href={web3.account ? 'https://connextscan.io/address/' + web3.account : 'https://connextscan.io/transactions'}
+            target="_blank"
+            rel="nofollow noreferrer"
+          >
+            <h2
+              style={{ display: 'inline' }}
+            >
+              Historical Transactions (<LinkOutlined />)
+            </h2>
+          </a>
+        </Row>
+
+        {/* Liquidity */}
+        <Row style={{ marginTop: 20 }} justify={"center"}>
+          <a
+            href={'https://connextscan.io/routers'}
+            target="_blank"
+            rel="nofollow noreferrer"
+          >
+            <h2
+              style={{ display: 'inline' }}
+            >
+              Available Liquidity (<LinkOutlined />)
+            </h2>
+          </a>
         </Row>
 
         {/* Footer */}

--- a/src/components/nxtp/SwapXpollinate.tsx
+++ b/src/components/nxtp/SwapXpollinate.tsx
@@ -849,7 +849,7 @@ const SwapXpollinate = ({
 
   const priceImpact = () => {
     const token = transferTokens[withdrawChain].find(token => token.id === withdrawToken)
-    let impact = new BigNumber(0)
+    // let impact = new BigNumber(0)
     let routerFee = new BigNumber(0)
     let gasFee = new BigNumber(0)
     let decimals = 2
@@ -865,7 +865,7 @@ const SwapXpollinate = ({
       const toAmount = new BigNumber(cross.estimate.toAmount).shiftedBy(-toToken.decimals)
 
       const diff = fromAmount.minus(toAmount)
-      impact = diff.div(fromAmount).times(-100)
+      // impact = diff.div(fromAmount).times(-100)
 
       gasFee = new BigNumber(cross.estimate.data.gasFeeInReceivingToken).shiftedBy(-toToken.decimals)
       routerFee = diff.minus(gasFee)
@@ -895,7 +895,7 @@ const SwapXpollinate = ({
             </tbody>
           </table>
         )}>
-          Fee Impact: {impact.toFixed(2)}%
+          Fee Impact
 
           <Badge count={<InfoCircleOutlined style={{ color: 'gray' }} />} offset={[4, -1]} />
         </Tooltip>


### PR DESCRIPTION
The historic transaction and the available liquidity is shown on connextscan.io. I replaced them on the website and link to the new site instead. This way no wrong liquidity is shown and liquidity for all token can be accessed.
![Screenshot 2021-11-09 at 1 55 08 PM](https://user-images.githubusercontent.com/3898310/140929237-b20ea14b-5b5a-407a-bc84-6ff69df4248c.png)
