### PR TITLE
🐕  Fix husky configuration

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn test
+yarn test:ci

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn test:ci
+yarn test:husky

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn test:husky
+yarn pre-push

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "build:xpollinate:testnet": "REACT_APP_ENV=xpollinate-testnet npm run build-env",
     "build:xpollinate:testnet:staging": "REACT_APP_ENV=xpollinate-testnet.staging npm run build-env",
     "test": "react-scripts test",
+    "test:ci": "react-scripts test --silent",
     "pre-commit": "lint-staged",
     "lint:fix": "eslint --ext .tsx --ext .ts ./src --fix",
     "prettier:fix": "prettier --write ./src/.",
@@ -86,12 +87,6 @@
       "yarn run lint:fix",
       "yarn run prettier:fix"
     ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged",
-      "pre-push": "yarn test:ci"
-    }
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "build:xpollinate:testnet": "REACT_APP_ENV=xpollinate-testnet npm run build-env",
     "build:xpollinate:testnet:staging": "REACT_APP_ENV=xpollinate-testnet.staging npm run build-env",
     "test": "react-scripts test",
-    "test:ci": "react-scripts test --silent",
+    "test:husky": "react-scripts test --watchAll=false",
     "pre-commit": "lint-staged",
     "lint:fix": "eslint --ext .tsx --ext .ts ./src --fix",
     "prettier:fix": "prettier --write ./src/.",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "build:xpollinate:testnet": "REACT_APP_ENV=xpollinate-testnet npm run build-env",
     "build:xpollinate:testnet:staging": "REACT_APP_ENV=xpollinate-testnet.staging npm run build-env",
     "test": "react-scripts test",
-    "test:husky": "react-scripts test --watchAll=false",
+    "pre-push": "react-scripts test --watchAll=false",
     "pre-commit": "lint-staged",
     "lint:fix": "eslint --ext .tsx --ext .ts ./src --fix",
     "prettier:fix": "prettier --write ./src/.",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "husky": ">=6",
+    "husky": "^7.0.0",
     "lint-staged": ">=10",
     "prettier": "2.4.1",
     "react-scripts": "4.0.3",
@@ -78,7 +78,8 @@
     "test": "react-scripts test",
     "pre-commit": "lint-staged",
     "lint:fix": "eslint --ext .tsx --ext .ts ./src --fix",
-    "prettier:fix": "prettier --write ./src/."
+    "prettier:fix": "prettier --write ./src/.",
+    "prepare": "husky install"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -8032,7 +8032,7 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-husky@>=6:
+husky@^7.0.0:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
   integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==


### PR DESCRIPTION
To enable husky you have to run `yarn install` once. There is a `prepare` step which will set it up.

**Important**: This works only for yarn < v2. For yarn v2 we need to do some changes