### PR TITLE
fix: use rounding function to render balance correctly

### DIFF
--- a/src/components/Swap.css
+++ b/src/components/Swap.css
@@ -28,7 +28,7 @@ input[type='number']::-webkit-outer-spin-button {
 }
 
 .swap-route:hover {
-   -webkit-box-shadow: 0px 0px 17px -6px rgba(23, 144, 255, 0.5);
+  -webkit-box-shadow: 0px 0px 17px -6px rgba(23, 144, 255, 0.5);
   box-shadow: 0px 0px 17px -6px rgba(23, 144, 255, 0.5);
 }
 

--- a/src/components/Swap.tsx
+++ b/src/components/Swap.tsx
@@ -461,10 +461,7 @@ const Swap = ({ transferChains }: SwapProps) => {
         } else {
           // balances loaded
           token.amount = getBalance(balances, chain.key, token.address)
-          token.amountRendered =
-            token.amount.gte(0.0001) || token.amount.isZero()
-              ? token.amount.toFixed(4)
-              : token.amount.toFixed()
+          token.amountRendered = formatTokenAmountOnly(token, token.amount)
         }
       }
     }

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -14,12 +14,17 @@ export const formatTokenAmount = (token: Token, amount: string | undefined) => {
   return formatTokenAmountOnly(token, amount) + ' ' + token.symbol
 }
 
-export const formatTokenAmountOnly = (token: Token, amount: string | undefined) => {
+export const formatTokenAmountOnly = (token: Token, amount: string | BigNumber | undefined) => {
   if (!amount) {
     return '0.0'
   }
 
-  const floated = new BigNumber(amount).shiftedBy(-token.decimals)
+  let floated
+  if (typeof amount === 'string') {
+    floated = new BigNumber(amount).shiftedBy(-token.decimals)
+  } else {
+    floated = amount
+  }
 
   // show at least 4 decimal places and at least two non-zero digests
   let decimalPlaces = 3


### PR DESCRIPTION
This should prevent these strange scenarios when you press the `MAX` button but the value differs from the balance

![image](https://user-images.githubusercontent.com/8833906/147942928-e32d84d1-f0cc-45d0-925c-1d6d7cecadbe.png)
