### PR TITLE
feat(SwapForm): show slippage tooltip at "to" amount

### DIFF
--- a/src/components/Swap.css
+++ b/src/components/Swap.css
@@ -28,7 +28,7 @@ input[type='number']::-webkit-outer-spin-button {
 }
 
 .swap-route:hover {
-   -webkit-box-shadow: 0px 0px 17px -6px rgba(23, 144, 255, 0.5);
+  -webkit-box-shadow: 0px 0px 17px -6px rgba(23, 144, 255, 0.5);
   box-shadow: 0px 0px 17px -6px rgba(23, 144, 255, 0.5);
 }
 

--- a/src/components/Swap.css
+++ b/src/components/Swap.css
@@ -268,7 +268,18 @@ h4.swap-title {
   opacity: 1;
 }
 
-.amountTooltip {
+.amountBadge {
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  font-size: 12px;
+  line-height: 14px;
+  border-radius: 7px;
+  background-color: gray;
+  color: white;
+  text-align: center;
+  font-weight: 400;
+  position: relative;
   right: 5px;
   cursor: default;
 }

--- a/src/components/Swap.css
+++ b/src/components/Swap.css
@@ -268,6 +268,11 @@ h4.swap-title {
   opacity: 1;
 }
 
+.amountTooltip {
+  right: 5px;
+  cursor: default;
+}
+
 .no-route-custom-collapse > .ant-collapse-item > .ant-collapse-header {
   color: grey;
   text-align: left;

--- a/src/components/Swap.tsx
+++ b/src/components/Swap.tsx
@@ -31,7 +31,7 @@ import { getRpcs } from '../config/connectors'
 import { deleteRoute, readActiveRoutes, readHistoricalRoutes } from '../services/localStorage'
 import { switchChain } from '../services/metamask'
 import { loadTokenListAsTokens } from '../services/tokenListService'
-import { deepClone, formatTokenAmountOnly } from '../services/utils'
+import { deepClone, formatTokenAmount, formatTokenAmountOnly } from '../services/utils'
 import {
   Chain,
   ChainId,
@@ -356,11 +356,16 @@ const Swap = ({ transferChains }: SwapProps) => {
 
   const getSelectedWithdraw = () => {
     if (highlightedIndex === -1) {
-      return '0.0'
+      return {
+        estimate: '0.0',
+      }
     } else {
       const selectedRoute = routes[highlightedIndex]
       const lastStep = selectedRoute.steps[selectedRoute.steps.length - 1]
-      return formatTokenAmountOnly(lastStep.action.toToken, lastStep.estimate?.toAmount)
+      return {
+        estimate: formatTokenAmountOnly(lastStep.action.toToken, lastStep.estimate?.toAmount),
+        min: formatTokenAmount(lastStep.action.toToken, lastStep.estimate?.toAmountMin),
+      }
     }
   }
 
@@ -781,7 +786,8 @@ const Swap = ({ transferChains }: SwapProps) => {
                   setWithdrawToken={setToTokenAddress}
                   withdrawAmount={withdrawAmount}
                   setWithdrawAmount={setWithdrawAmount}
-                  estimatedWithdrawAmount={getSelectedWithdraw()}
+                  estimatedWithdrawAmount={getSelectedWithdraw().estimate}
+                  estimatedMinWithdrawAmount={getSelectedWithdraw().min}
                   transferChains={transferChains}
                   tokens={tokens}
                   balances={balances}

--- a/src/components/SwapForm.tsx
+++ b/src/components/SwapForm.tsx
@@ -26,6 +26,7 @@ interface SwapFormProps {
   withdrawAmount: BigNumber
   setWithdrawAmount: Function
   estimatedWithdrawAmount: string
+  estimatedMinWithdrawAmount?: string
 
   transferChains: Array<Chain>
   tokens: { [ChainKey: string]: Array<TokenWithAmounts> }
@@ -50,6 +51,7 @@ const SwapForm = ({
   withdrawAmount,
   setWithdrawAmount,
   estimatedWithdrawAmount,
+  estimatedMinWithdrawAmount,
 
   transferChains,
   tokens,
@@ -294,12 +296,13 @@ const SwapForm = ({
               bordered={false}
               disabled
             />
-            <Tooltip
-              className="amountTooltip"
-              color={'gray'}
-              title="The final amount might change due to slippage">
-              <Badge size="small" count={'?'} style={{ backgroundColor: 'gray' }} />
-            </Tooltip>
+            {estimatedMinWithdrawAmount && (
+              <Tooltip
+                color={'gray'}
+                title={`The final amount might change due to slippage but will not fall below ${estimatedMinWithdrawAmount}`}>
+                <span className="amountBadge">?</span>
+              </Tooltip>
+            )}
           </div>
         </Col>
         <Col span={14}>

--- a/src/components/SwapForm.tsx
+++ b/src/components/SwapForm.tsx
@@ -1,7 +1,7 @@
 import { SwapOutlined } from '@ant-design/icons'
 import { SubgraphSyncRecord } from '@connext/nxtp-sdk'
 import { useWeb3React } from '@web3-react/core'
-import { Button, Col, Input, Row } from 'antd'
+import { Badge, Button, Col, Input, Row, Tooltip } from 'antd'
 import { RefSelectProps } from 'antd/lib/select'
 import BigNumber from 'bignumber.js'
 import React, { useEffect, useRef, useState } from 'react'
@@ -294,6 +294,12 @@ const SwapForm = ({
               bordered={false}
               disabled
             />
+            <Tooltip
+              className="amountTooltip"
+              color={'gray'}
+              title="The final amount might change due to slippage">
+              <Badge size="small" count={'?'} style={{ backgroundColor: 'gray' }} />
+            </Tooltip>
           </div>
         </Col>
         <Col span={14}>

--- a/src/components/SwapForm.tsx
+++ b/src/components/SwapForm.tsx
@@ -1,7 +1,7 @@
 import { SwapOutlined } from '@ant-design/icons'
 import { SubgraphSyncRecord } from '@connext/nxtp-sdk'
 import { useWeb3React } from '@web3-react/core'
-import { Badge, Button, Col, Input, Row, Tooltip } from 'antd'
+import { Button, Col, Input, Row, Tooltip } from 'antd'
 import { RefSelectProps } from 'antd/lib/select'
 import BigNumber from 'bignumber.js'
 import React, { useEffect, useRef, useState } from 'react'

--- a/src/components/SwapForm.tsx
+++ b/src/components/SwapForm.tsx
@@ -296,7 +296,7 @@ const SwapForm = ({
               bordered={false}
               disabled
             />
-            {estimatedMinWithdrawAmount && (
+            {!!estimatedMinWithdrawAmount && (
               <Tooltip
                 color={'gray'}
                 title={`The final amount might change due to slippage but will not fall below ${estimatedMinWithdrawAmount}`}>


### PR DESCRIPTION
Users are often confused why the final amount differs from the one shown initially. For this reason we should provide a clear message telling them that this is just an estimation.

![image](https://user-images.githubusercontent.com/8833906/148034184-95f63d06-d6a4-4be5-8f1e-39f8e560f88a.png)

![image](https://user-images.githubusercontent.com/8833906/148034216-2e202f2f-75c0-44a1-8ba6-a1cdb26260ec.png)
