### PR TITLE
build: run workflow on pull_request events

### DIFF
--- a/.github/workflows/build_others.yml
+++ b/.github/workflows/build_others.yml
@@ -9,7 +9,7 @@ on:
     branches-ignore:
       - main
       - develop
-  pull_request
+  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/build_others.yml
+++ b/.github/workflows/build_others.yml
@@ -9,6 +9,7 @@ on:
     branches-ignore:
       - main
       - develop
+  pull_request
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
If people create a PR from their forked repository of by editing in Github directly no `push` event will be triggered to run the prettier and eslint checks. For those cases we need to run on `pull_request` events.

