### PR TITLE
feat: show estimated duration for routes and steps

### DIFF
--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 
+import { parseSecondsAsTime } from '../services/utils'
+
 interface ClockProps {
   startedAt: number
   successAt?: number | undefined
@@ -22,11 +24,7 @@ const Clock = ({ startedAt, successAt, failedAt }: ClockProps) => {
 
   const renderTime = () => {
     const total = getCount()
-    const minutes = Math.floor(total / 60)
-    const seconds = total % 60
-    const prefix = seconds < 10 ? '0' : ''
-
-    return `${minutes}:${prefix}${seconds}`
+    return parseSecondsAsTime(total)
   }
 
   useEffect(() => {

--- a/src/components/Route.tsx
+++ b/src/components/Route.tsx
@@ -1,6 +1,6 @@
 import { Button, Steps } from 'antd'
 
-import { formatTokenAmount } from '../services/utils'
+import { formatTokenAmount, parseSecondsAsTime } from '../services/utils'
 import { findTool, getChainById, Route as RouteType, Step } from '../types'
 
 interface RouteProps {
@@ -89,6 +89,13 @@ const Route = ({ route, selected, onSelect }: RouteProps) => {
     }
   }
 
+  const aggregatedDuration = route.steps.reduce<number>(
+    (duration, step) => duration + step.estimate?.executionDuration || 1,
+    0,
+  )
+
+  const parsedDuration = parseSecondsAsTime(aggregatedDuration)
+
   return (
     <div
       className={'swap-route ' + (selected ? 'optimal' : '')}
@@ -121,6 +128,8 @@ const Route = ({ route, selected, onSelect }: RouteProps) => {
           Estimated result: {route.toAmountUSD} USD
           <br />
           Estimated gas costs: {route.gasCostUSD} USD
+          <br />
+          Estimated duration: {parsedDuration} min
           <br />
         </div>
 

--- a/src/components/Swap.css
+++ b/src/components/Swap.css
@@ -65,7 +65,7 @@ input[type='number']::-webkit-outer-spin-button {
 }
 
 .progress-step-list {
-  margin-bottom: 90px;
+  margin-bottom: 120px;
 }
 
 .progress-step-title {

--- a/src/components/Swapping.tsx
+++ b/src/components/Swapping.tsx
@@ -19,7 +19,7 @@ import { storeRoute } from '../services/localStorage'
 import { switchChain, switchChainAndAddToken } from '../services/metamask'
 import Notification, { NotificationType } from '../services/notifications'
 import { renderProcessError, renderProcessMessage } from '../services/processRenderer'
-import { formatTokenAmount } from '../services/utils'
+import { formatTokenAmount, parseSecondsAsTime } from '../services/utils'
 import {
   ChainKey,
   findTool,
@@ -140,6 +140,13 @@ const Swapping = ({ route, updateRoute, onSwapDone }: SwappingProps) => {
     const isLoading = isSwapping && step.execution && step.execution.status === 'PENDING'
     const isPaused = !isSwapping && step.execution && step.execution.status === 'PENDING'
     const color = isDone ? 'green' : step.execution ? 'blue' : 'gray'
+    const executionDuration = !!step.estimate.executionDuration && (
+      <>
+        <br />
+        <span>Estimated duration: {parseSecondsAsTime(step.estimate.executionDuration)} min</span>
+      </>
+    )
+
     switch (step.type) {
       case 'swap': {
         return [
@@ -153,6 +160,7 @@ const Swapping = ({ route, updateRoute, onSwapDone }: SwappingProps) => {
               <ArrowRightOutlined />{' '}
               {formatTokenAmount(step.action.toToken, step.estimate?.toAmount)}
             </span>
+            {executionDuration}
           </Timeline.Item>,
           <Timeline.Item
             position={isMobile ? 'right' : 'left'}
@@ -179,6 +187,7 @@ const Swapping = ({ route, updateRoute, onSwapDone }: SwappingProps) => {
               {formatTokenAmount(action.fromToken, estimate.fromAmount)} <ArrowRightOutlined />{' '}
               {formatTokenAmount(action.toToken, estimate.toAmount)}
             </span>
+            {executionDuration}
           </Timeline.Item>,
           <Timeline.Item
             position={isMobile ? 'right' : 'left'}
@@ -206,6 +215,7 @@ const Swapping = ({ route, updateRoute, onSwapDone }: SwappingProps) => {
               <ArrowRightOutlined />{' '}
               {formatTokenAmount(step.action.toToken, step.estimate?.toAmount)}
             </span>
+            {executionDuration}
           </Timeline.Item>,
           <Timeline.Item
             position={isMobile ? 'right' : 'left'}

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -55,3 +55,17 @@ export const isWalletDeactivated = (address: string | null | undefined): boolean
   const deactivatedAddresses = deactivatedWallets.map((address) => address.toLowerCase())
   return deactivatedAddresses.includes(lowerCaseAddress)
 }
+
+/**
+ * Parses seconds as time string in the format "02:25"
+ * @param seconds
+ */
+export const parseSecondsAsTime = (seconds: number): string => {
+  if (isNaN(seconds) || seconds < 0) {
+    return ' - '
+  }
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = Math.ceil(seconds % 60)
+  const prefix = remainingSeconds < 10 ? '0' : ''
+  return `${minutes}:${prefix}${remainingSeconds}`
+}

--- a/src/services/utils.unit.spec.ts
+++ b/src/services/utils.unit.spec.ts
@@ -1,7 +1,7 @@
 import { ChainId, CoinKey, findDefaultToken } from '@lifinance/sdk'
 import BigNumber from 'bignumber.js'
 
-import { formatTokenAmountOnly } from './utils'
+import { formatTokenAmountOnly, parseSecondsAsTime } from './utils'
 
 const SOME_TOKEN = findDefaultToken(CoinKey.USDC, ChainId.DAI)
 
@@ -101,6 +101,45 @@ describe('utils', () => {
         expect(formatTokenAmountOnly(SOME_TOKEN_WITH_0_DECIMALS, new BigNumber('11'))).toEqual(
           '11.0000',
         )
+      })
+    })
+  })
+
+  describe('parseSecondsAsTime', () => {
+    describe('when the passed value is not a number', () => {
+      it('should return a placeholder', () => {
+        const time = parseSecondsAsTime('what?' as unknown as number)
+        expect(time).toEqual(' - ')
+      })
+    })
+
+    describe('when the passed value is below zero', () => {
+      it('should return a placeholder', () => {
+        const time = parseSecondsAsTime(-5)
+        expect(time).toEqual(' - ')
+      })
+    })
+
+    describe('when the passed value is valid', () => {
+      describe('and it has a one digit amount of seconds', () => {
+        it('should add a padding 0', () => {
+          const time = parseSecondsAsTime(61)
+          expect(time).toEqual('1:01')
+        })
+      })
+
+      describe('and it has a two digit amount of seconds', () => {
+        it('should not add a padding 0', () => {
+          const time = parseSecondsAsTime(83)
+          expect(time).toEqual('1:23')
+        })
+      })
+
+      describe('and it contains a fraction', () => {
+        it('should round to 2 digits', () => {
+          const time = parseSecondsAsTime(83.12345)
+          expect(time).toEqual('1:24')
+        })
       })
     })
   })


### PR DESCRIPTION
This just shows the estimated duration for a route and for each step in a very simple way:

## On the available routes:
![Screen Shot 2022-02-08 at 11 23 07](https://user-images.githubusercontent.com/8833906/152970268-6e234d19-65f9-44e3-8e41-67eb6f776a19.png)

## On the available steps:
![Screen Shot 2022-02-08 at 11 17 08](https://user-images.githubusercontent.com/8833906/152970274-2914fc5b-a37e-454d-afe4-e233c5580184.png)
