### PR TITLE
feat: change Docs link to "Explore Docs"

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,7 +122,7 @@ function App() {
                           href="https://docs.li.finance/"
                           target="_blank"
                           rel="nofollow noreferrer">
-                          Docs
+                          Explore Docs
                         </a>
                       </Menu.Item>
                       {/* <Menu.Item>


### PR DESCRIPTION
[LF-349](https://lifi.atlassian.net/jira/software/c/projects/LF/boards/6?modal=detail&selectedIssue=LF-349&quickFilter=10)
The "Docs" button on Li.Finance is not very actionable. It should encourage to click on it -> Change the Button text to "Explore Docs"