### PR TITLE
build: use develop instead of staging for local testing

### DIFF
--- a/.env.development.developBackend
+++ b/.env.development.developBackend
@@ -1,0 +1,1 @@
+REACT_APP_API_URL="https://developkub.li.finance/v1/"

--- a/.env.development.stagingBackend
+++ b/.env.development.stagingBackend
@@ -1,1 +1,0 @@
-REACT_APP_API_URL="https://staging.li.quest/v1/"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "start:stagingBackend": "bash -ac '. .env.development.stagingBackend; react-scripts start'",
+    "start:developBackend": "bash -ac '. .env.development.developBackend; react-scripts start'",
     "start-env": "bash -ac '. .env.${REACT_APP_ENV}; react-scripts start'",
     "build": "react-scripts build",
     "build-env": "bash -ac '. .env.${REACT_APP_ENV}; react-scripts build'",


### PR DESCRIPTION
Since we now differentiate between staging and develop environment it makes more sense to use the develop stage for local development instead of the staging stage.
