### PR TITLE
feat: remove encryption functionality

### DIFF
--- a/src/components/Swap.tsx
+++ b/src/components/Swap.tsx
@@ -311,7 +311,6 @@ const Swap = ({ transferChains }: SwapProps) => {
   // Options
   const [optionSlippage, setOptionSlippage] = useState<number>(3)
   const [optionInfiniteApproval, setOptionInfiniteApproval] = useState<boolean>(true)
-  const [optionEncryption, setOptionEncryption] = useState<boolean>(false)
   const [optionEnabledBridges, setOptionEnabledBridges] = useState<string[] | undefined>()
   const [availableBridges, setAvailableBridges] = useState<string[]>([])
   const [optionEnabledExchanges, setOptionEnabledExchanges] = useState<string[] | undefined>()
@@ -956,14 +955,6 @@ const Swap = ({ transferChains }: SwapProps) => {
                             Activate Infinite Approval
                           </Checkbox>
                         </div>
-                        Encryption (Connext only)
-                        <div>
-                          <Checkbox
-                            checked={optionEncryption}
-                            onChange={(e) => setOptionEncryption(e.target.checked)}>
-                            Activate Encryption
-                          </Checkbox>
-                        </div>
                         Bridges
                         <div>
                           <Select
@@ -1082,9 +1073,6 @@ const Swap = ({ transferChains }: SwapProps) => {
           footer={null}>
           <Swapping
             route={selectedRoute}
-            options={{
-              encryption: optionEncryption,
-            }}
             updateRoute={() => {
               setActiveRoutes(readActiveRoutes())
               setHistoricalRoutes(readHistoricalRoutes())

--- a/src/components/Swapping.tsx
+++ b/src/components/Swapping.tsx
@@ -1,11 +1,6 @@
 import { ArrowRightOutlined, LoadingOutlined, PauseCircleOutlined } from '@ant-design/icons'
 import { Web3Provider } from '@ethersproject/providers'
-import LiFi, {
-  ExecutionSettings,
-  getEthereumDecryptionHook,
-  getEthereumPublicKeyHook,
-  StepTool,
-} from '@lifinance/sdk'
+import LiFi, { ExecutionSettings, StepTool } from '@lifinance/sdk'
 import { useWeb3React } from '@web3-react/core'
 import { Avatar, Button, Divider, Row, Space, Spin, Timeline, Tooltip, Typography } from 'antd'
 import BigNumber from 'bignumber.js'

--- a/src/components/Swapping.tsx
+++ b/src/components/Swapping.tsx
@@ -38,9 +38,6 @@ interface SwappingProps {
   route: Route
   updateRoute: Function
   onSwapDone: Function
-  options: {
-    encryption: boolean
-  }
 }
 
 const getFinalBalance = (account: string, route: Route): Promise<TokenAmount | null> => {
@@ -55,7 +52,7 @@ const getReceivingInfo = (step: Step) => {
   return { toChain, toToken }
 }
 
-const Swapping = ({ route, updateRoute, onSwapDone, options }: SwappingProps) => {
+const Swapping = ({ route, updateRoute, onSwapDone }: SwappingProps) => {
   const { steps } = route
 
   const isMobile = useMediaQuery({ query: `(max-width: 760px)` })
@@ -244,12 +241,6 @@ const Swapping = ({ route, updateRoute, onSwapDone, options }: SwappingProps) =>
     const settings: ExecutionSettings = {
       updateCallback: updateCallback,
       switchChainHook: switchChainHook,
-      decryptHook: options.encryption
-        ? getEthereumDecryptionHook(await signer.getAddress())
-        : undefined,
-      getPublicKeyHook: options.encryption
-        ? getEthereumPublicKeyHook(await signer.getAddress())
-        : undefined,
     }
     storeRoute(route)
     setIsSwapping(true)
@@ -274,17 +265,10 @@ const Swapping = ({ route, updateRoute, onSwapDone, options }: SwappingProps) =>
 
   const resumeExecution = async () => {
     if (!web3.account || !web3.library) return
-    const signer = web3.library.getSigner()
 
     const settings: ExecutionSettings = {
       updateCallback,
       switchChainHook,
-      decryptHook: options.encryption
-        ? getEthereumDecryptionHook(await signer.getAddress())
-        : undefined,
-      getPublicKeyHook: options.encryption
-        ? getEthereumPublicKeyHook(await signer.getAddress())
-        : undefined,
     }
 
     setIsSwapping(true)


### PR DESCRIPTION
We want to use the /status endpoint in the SDK instead of the Connext SDK. For that reason we cannot allow encryption in the frontend anymore.
At a later point we will handle the encryption in the backend, for now we completely remove it from the user interface
