### PR TITLE
fix: show actually received amount and token

### DIFF
--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -133,13 +133,19 @@ function TrasactionsTable({
     const lastStep = route.steps[route.steps.length - 1]
     let toChainId = lastStep.action.toChainId
 
+    // take the real received value instead of the estimation if possible
+    const toAmount = lastStep.execution?.toAmount ?? lastStep.estimate.toAmount
+    // in case the destination swap fails the user receives the bridge token and the transaction is marked as successful.
+    // we need to make sure to always show the token the user actually received
+    const toToken = lastStep.execution?.toToken ?? lastStep.action.toToken
+
     return {
       key: index,
       date: startedDate,
       fromChain: getChainById(firstStep.action.fromChainId).name,
       toChain: getChainById(toChainId).name,
       fromToken: `${formatTokenAmount(firstStep.action.fromToken, firstStep.estimate.fromAmount)}`,
-      toToken: `${formatTokenAmount(lastStep.action.toToken, lastStep.estimate.toAmount)}`,
+      toToken: `${formatTokenAmount(toToken, toAmount)}`,
       protocols: route.steps.map((step) => findTool(step.tool)?.name).join(' > '),
       state: getStateText(route),
       action: renderActionButton(route),


### PR DESCRIPTION
The actually received amount differs from the estimated amount. We should show the received amount if possible.
Also the received token differs in case the destination swap fails and the user receives the bridged token.

(Requires a [sdk release](https://github.com/lifinance/sdk/pull/45))
