### PR TITLE
fix: use token defined in chain to do gas check

### DIFF
--- a/src/components/Swap.tsx
+++ b/src/components/Swap.tsx
@@ -608,7 +608,8 @@ const Swap = () => {
     }
 
     const fromChain = getChainById(route.fromChainId)
-    const balance = getBalance(balances, fromChain.key, ethers.constants.AddressZero)
+    const token = findDefaultToken(fromChain.coin, fromChain.id)
+    const balance = getBalance(balances, fromChain.key, token.address)
 
     const requiredAmount = route.steps
       .filter((step) => step.action.fromChainId === route.fromChainId)
@@ -634,7 +635,8 @@ const Swap = () => {
     }
 
     const crossChain = getChainById(lastStep.action.fromChainId)
-    const balance = getBalance(balances, crossChain.key, ethers.constants.AddressZero)
+    const token = findDefaultToken(crossChain.coin, crossChain.id)
+    const balance = getBalance(balances, crossChain.key, token.address)
 
     const gasEstimate =
       lastStep.estimate.gasCosts &&

--- a/src/components/SwapUkraine.tsx
+++ b/src/components/SwapUkraine.tsx
@@ -602,7 +602,8 @@ const Swap = () => {
     }
 
     const fromChain = getChainById(route.fromChainId)
-    const balance = getBalance(balances, fromChain.key, ethers.constants.AddressZero)
+    const token = findDefaultToken(fromChain.coin, fromChain.id)
+    const balance = getBalance(balances, fromChain.key, token.address)
 
     const requiredAmount = route.steps
       .filter((step) => step.action.fromChainId === route.fromChainId)
@@ -628,7 +629,8 @@ const Swap = () => {
     }
 
     const crossChain = getChainById(lastStep.action.fromChainId)
-    const balance = getBalance(balances, crossChain.key, ethers.constants.AddressZero)
+    const token = findDefaultToken(crossChain.coin, crossChain.id)
+    const balance = getBalance(balances, crossChain.key, token.address)
 
     const gasEstimate =
       lastStep.estimate.gasCosts &&


### PR DESCRIPTION
CELO chain's native token is not on address zero: https://explorer.celo.org/token/0x471EcE3750Da237f93B8E339c536989b8978a438/token-transfers
So far we just assumed that the gas token is always on 0x0. Instead we should use the token configured in our chain list.