### PR TITLE
fix: keep routes after modal open

### DIFF
--- a/src/components/Swap.tsx
+++ b/src/components/Swap.tsx
@@ -749,11 +749,6 @@ const Swap = () => {
   const openModal = () => {
     // deepClone to open new modal without execution info of previous transfer using same route card
     setSelectedRoute(deepClone(routes[highlightedIndex]))
-
-    // Reset routes to avoid reexecution with same data
-    setRoutes([])
-    setHighlightedIndex(-1)
-    setNoRoutesAvailable(false)
   }
 
   const switchChain = async (chainId: number) => {


### PR DESCRIPTION
now that the connext ids are generated on the server we can keep routes after the modal has been opened