### PR TITLE
style: fix alignment

### DIFF
--- a/src/components/Swapping.tsx
+++ b/src/components/Swapping.tsx
@@ -107,10 +107,10 @@ const Swapping = ({
                 <div
                   style={{
                     display: 'flex',
-                    justifyContent: 'flex-start',
+                    justifyContent: 'start',
                   }}>
                   <Button
-                    style={{ margin: 0 }}
+                    style={{ margin: 0, padding: 0 }}
                     type="link"
                     onClick={async () =>
                       copyToClipboard(


### PR DESCRIPTION
Fixed the alignment of the error buttons

<img width="787" alt="image" src="https://user-images.githubusercontent.com/10106351/176714973-4d8ce4ef-9de5-4f68-a957-7b136d5e08b7.png">

Note: normally in this case only one button would be shown. not both. This is for demonstration only
