### PR TITLE
fix: new develop endpoint

### DIFF
--- a/.env.development.developBackend
+++ b/.env.development.developBackend
@@ -1,1 +1,1 @@
-VITE_API_URL="https://developkub.li.finance/v1/"
+VITE_API_URL="https://develop.li.quest/v1/"

--- a/.env.lifinance-mainnet.develop
+++ b/.env.lifinance-mainnet.develop
@@ -1,4 +1,4 @@
-VITE_API_URL="https://developkub.li.finance/v1/"
+VITE_API_URL="https://develop.li.quest/v1/"
 
 # testing nodereal speed and reliability (FE-ETH-develop)
 VITE_RPC_URL_MAINNET="https://eth-mainnet.nodereal.io/v1/6a4b7361250d4905ac9ee30c01dbd7fc"


### PR DESCRIPTION
Using a new develop endpoint (develop.li.quest) in order to use the same DNS endpoint of our staging/production releases. If they are referenced in other parts and/or in different ways, let me know 🙂